### PR TITLE
映像処理に関わるファイル保存変更

### DIFF
--- a/comp_pose.py
+++ b/comp_pose.py
@@ -5,7 +5,7 @@ import cv2
 import numpy as np
 import time
 import math
-import gdown
+import os
 from collections import defaultdict, deque
 import logging
 
@@ -198,7 +198,7 @@ class DrowsinessDetectionSystem:
             logger.error("RTSPカメラに接続できません")
             return'''
 
-    def run_on_video(self, video_path, save_path="output.mp4", result_log="frame_results.csv"):
+def run_on_video(self, video_path, save_path="output.mp4", result_log="frame_results.csv"):
         cap = cv2.VideoCapture(video_path)
         if not cap.isOpened():
             logger.error("動画ファイルに接続できません")
@@ -212,9 +212,15 @@ class DrowsinessDetectionSystem:
         if self.K is None:
             self.initialize_camera_params(width, height)
 
+        # 既存ファイルがある場合は削除
+        if os.path.exists(save_path):
+            os.remove(save_path)
+        if os.path.exists(result_log):
+            os.remove(result_log)
+
         # 保存用ビデオライターの設定
         fourcc = cv2.VideoWriter_fourcc(*'mp4v')
-        out = cv2.VideoWriter("output.mp4", fourcc, fps, (width, height))
+        out = cv2.VideoWriter("input_videos/output.mp4", fourcc, fps, (width, height))
 
         # 結果ログ
         import csv

--- a/downloader.py
+++ b/downloader.py
@@ -13,7 +13,7 @@ def download_file_from_google_drive(file_id: str, save_dir="input_videos", file_
         os.makedirs(save_dir)
 
     if file_name is None:
-        file_name = f"{file_id}.mp4"
+        file_name = f"input.mp4"
 
     file_path = os.path.join(save_dir, file_name)
 


### PR DESCRIPTION
推論を行うたびにoutput.mp4の動画が最新のものに置き換わるようにした。
元々CSVファイルは最新の結果で反映されるようにしていたので、今回の変更で映像とログの関連がわかりやすい構造となった。